### PR TITLE
Set Spring Boot context-path to /api

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/beacons}
     username: ${SPRING_DATASOURCE_USER:beacons-service}
     password: ${SPRING_DATASOURCE_PASSWORD:password}
+
+server:
+  servlet:
+    context-path: /api


### PR DESCRIPTION
- Update Spring Boot context-path to `/api` for reverse proxying through the application gateway