### PR TITLE
Tag Docker images using the git hash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,10 +71,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Extract branch name
-        shell: bash
-        run: REF=${GITHUB_REF#refs/heads/} && arrREF=(${REF//// }) && echo "##[set-output name=branch;]$(echo ${arrREF[-1]})"
-        id: extract_branch
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to ECR
@@ -87,7 +83,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.AWS_ECR_REGISTRY }}/${{ secrets.AWS_ECR_REPOSITORY }}:${{ steps.extract_branch.outputs.branch }}
+          tags: ${{ secrets.AWS_ECR_REGISTRY }}/${{ secrets.AWS_ECR_REPOSITORY }}:${{ github.sha }}
 
   codeql_check:
     name: CodeQL check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   beacons-service:
     build:
       context: ./
-    container_name: app
+    container_name: beacons-service
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
- Removes the step for extracting the branch name
- Tags the Docker images using the hash of the commit rather than the tag