### PR TITLE
Set up initial endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
 	runtimeOnly 'org.postgresql:postgresql'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/uk/gov/mca/beacons/service/BeaconsRegistrationService.java
+++ b/src/main/java/uk/gov/mca/beacons/service/BeaconsRegistrationService.java
@@ -2,8 +2,10 @@ package uk.gov.mca.beacons.service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BeaconsRegistrationService {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
@@ -1,13 +1,19 @@
 package uk.gov.mca.beacons.service.model;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "beacons")
 public class Beacon {
 
@@ -22,6 +28,13 @@ public class Beacon {
   private String serialNumber;
   private LocalDate batteryExpiry;
   private LocalDate lastServiced;
+  private String chkCode;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime lastModifiedDate;
 
   public void setId(UUID id) {
     this.id = id;
@@ -85,5 +98,13 @@ public class Beacon {
 
   public void setLastServiced(LocalDate lastServiced) {
     this.lastServiced = lastServiced;
+  }
+
+  public String getChkCode() {
+    return chkCode;
+  }
+
+  public void setChkCode(String chkCode) {
+    this.chkCode = chkCode;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
@@ -107,4 +107,20 @@ public class Beacon {
   public void setChkCode(String chkCode) {
     this.chkCode = chkCode;
   }
+
+  public LocalDateTime getCreatedDate() {
+    return createdDate;
+  }
+
+  public void setCreatedDate(LocalDateTime createdDate) {
+    this.createdDate = createdDate;
+  }
+
+  public LocalDateTime getLastModifiedDate() {
+    return lastModifiedDate;
+  }
+
+  public void setLastModifiedDate(LocalDateTime lastModifiedDate) {
+    this.lastModifiedDate = lastModifiedDate;
+  }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Beacon.java
@@ -28,7 +28,10 @@ public class Beacon {
   private String serialNumber;
   private LocalDate batteryExpiry;
   private LocalDate lastServiced;
-  private String chkCode;
+  private String checksum;
+  private String beaconStatus;
+  private String coding;
+  private String protocolCode;
 
   @CreatedDate
   private LocalDateTime createdDate;
@@ -36,12 +39,12 @@ public class Beacon {
   @LastModifiedDate
   private LocalDateTime lastModifiedDate;
 
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
   public UUID getId() {
     return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
   }
 
   public String getBeaconType() {
@@ -100,12 +103,36 @@ public class Beacon {
     this.lastServiced = lastServiced;
   }
 
-  public String getChkCode() {
-    return chkCode;
+  public String getChecksum() {
+    return checksum;
   }
 
-  public void setChkCode(String chkCode) {
-    this.chkCode = chkCode;
+  public void setChecksum(String checksum) {
+    this.checksum = checksum;
+  }
+
+  public String getBeaconStatus() {
+    return beaconStatus;
+  }
+
+  public void setBeaconStatus(String beaconStatus) {
+    this.beaconStatus = beaconStatus;
+  }
+
+  public String getCoding() {
+    return coding;
+  }
+
+  public void setCoding(String coding) {
+    this.coding = coding;
+  }
+
+  public String getProtocolCode() {
+    return protocolCode;
+  }
+
+  public void setProtocolCode(String protocolCode) {
+    this.protocolCode = protocolCode;
   }
 
   public LocalDateTime getCreatedDate() {

--- a/src/main/java/uk/gov/mca/beacons/service/model/BeaconPerson.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/BeaconPerson.java
@@ -1,11 +1,17 @@
 package uk.gov.mca.beacons.service.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class BeaconPerson {
 
   @Id
@@ -14,6 +20,12 @@ public class BeaconPerson {
 
   private UUID beaconId;
   private UUID personId;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime lastModifiedDate;
 
   public UUID getId() {
     return id;

--- a/src/main/java/uk/gov/mca/beacons/service/model/BeaconPersonRepository.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/BeaconPersonRepository.java
@@ -2,8 +2,8 @@ package uk.gov.mca.beacons.service.model;
 
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@Repository
+@RepositoryRestResource(exported = false)
 public interface BeaconPersonRepository
   extends CrudRepository<BeaconPerson, UUID> {}

--- a/src/main/java/uk/gov/mca/beacons/service/model/BeaconUse.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/BeaconUse.java
@@ -25,7 +25,7 @@ public class BeaconUse {
   private boolean mainUse;
   private UUID beaconPersonId;
   private UUID vesselId;
-  private String location;
+  private String beaconPosition;
 
   @CreatedDate
   private LocalDateTime createdDate;
@@ -81,11 +81,11 @@ public class BeaconUse {
     this.vesselId = vesselId;
   }
 
-  public String getLocation() {
-    return location;
+  public String getBeaconPosition() {
+    return beaconPosition;
   }
 
-  public void setLocation(String location) {
-    this.location = location;
+  public void setBeaconPosition(String location) {
+    this.beaconPosition = location;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/BeaconUse.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/BeaconUse.java
@@ -1,12 +1,18 @@
 package uk.gov.mca.beacons.service.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "beacon_uses")
 public class BeaconUse {
 
@@ -19,6 +25,13 @@ public class BeaconUse {
   private boolean mainUse;
   private UUID beaconPersonId;
   private UUID vesselId;
+  private String location;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime lastModifiedDate;
 
   public UUID getId() {
     return id;
@@ -66,5 +79,13 @@ public class BeaconUse {
 
   public void setVesselId(UUID vesselId) {
     this.vesselId = vesselId;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public void setLocation(String location) {
+    this.location = location;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/BeaconUseRepository.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/BeaconUseRepository.java
@@ -2,7 +2,7 @@ package uk.gov.mca.beacons.service.model;
 
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@Repository
+@RepositoryRestResource(path = "beacon-uses")
 public interface BeaconUseRepository extends CrudRepository<BeaconUse, UUID> {}

--- a/src/main/java/uk/gov/mca/beacons/service/model/Person.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Person.java
@@ -1,13 +1,19 @@
 package uk.gov.mca.beacons.service.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table
 public class Person {
 
@@ -19,6 +25,12 @@ public class Person {
   private String name;
   private String telephone;
   private String emailAddress;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime lastModifiedDate;
 
   @Column(name = "address_line_1")
   private String addressLine1;

--- a/src/main/java/uk/gov/mca/beacons/service/model/Person.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Person.java
@@ -44,14 +44,9 @@ public class Person {
   @Column(name = "address_line_4")
   private String addressLine4;
 
-  @Column(name = "address_line_5")
-  private String addressLine5;
-
-  @Column(name = "address_line_6")
-  private String addressLine6;
-
-  @Column(name = "address_line_7")
-  private String addressLine7;
+  private String postcode;
+  private String country;
+  private String careOf;
 
   public UUID getId() {
     return id;
@@ -93,6 +88,22 @@ public class Person {
     this.emailAddress = emailAddress;
   }
 
+  public LocalDateTime getCreatedDate() {
+    return createdDate;
+  }
+
+  public void setCreatedDate(LocalDateTime createdDate) {
+    this.createdDate = createdDate;
+  }
+
+  public LocalDateTime getLastModifiedDate() {
+    return lastModifiedDate;
+  }
+
+  public void setLastModifiedDate(LocalDateTime lastModifiedDate) {
+    this.lastModifiedDate = lastModifiedDate;
+  }
+
   public String getAddressLine1() {
     return addressLine1;
   }
@@ -125,27 +136,27 @@ public class Person {
     this.addressLine4 = addressLine4;
   }
 
-  public String getAddressLine5() {
-    return addressLine5;
+  public String getPostcode() {
+    return postcode;
   }
 
-  public void setAddressLine5(String addressLine5) {
-    this.addressLine5 = addressLine5;
+  public void setPostcode(String postcode) {
+    this.postcode = postcode;
   }
 
-  public String getAddressLine6() {
-    return addressLine6;
+  public String getCountry() {
+    return country;
   }
 
-  public void setAddressLine6(String addressLine6) {
-    this.addressLine6 = addressLine6;
+  public void setCountry(String country) {
+    this.country = country;
   }
 
-  public String getAddressLine7() {
-    return addressLine7;
+  public String getCareOf() {
+    return careOf;
   }
 
-  public void setAddressLine7(String addressLine7) {
-    this.addressLine7 = addressLine7;
+  public void setCareOf(String careOf) {
+    this.careOf = careOf;
   }
 }

--- a/src/main/java/uk/gov/mca/beacons/service/model/Vessel.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Vessel.java
@@ -1,11 +1,17 @@
 package uk.gov.mca.beacons.service.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Vessel {
 
   @Id
@@ -18,6 +24,12 @@ public class Vessel {
   private String radioComms;
   private Integer capacity;
   private String vesselType;
+
+  @CreatedDate
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime lastModifiedDate;
 
   public UUID getId() {
     return id;

--- a/src/main/java/uk/gov/mca/beacons/service/model/Vessel.java
+++ b/src/main/java/uk/gov/mca/beacons/service/model/Vessel.java
@@ -18,12 +18,18 @@ public class Vessel {
   @GeneratedValue
   private UUID id;
 
-  private String mmsi;
+  private String description;
+  private Integer vesselMmsi;
+  private Integer portableMsi;
   private String name;
   private String callsign;
   private String radioComms;
-  private Integer capacity;
+  private Integer maxCapacity;
   private String vesselType;
+  private String uksrId;
+  private String safetraxId;
+  private String homeport;
+  private String areaOfUse;
 
   @CreatedDate
   private LocalDateTime createdDate;
@@ -39,12 +45,28 @@ public class Vessel {
     this.id = id;
   }
 
-  public String getMmsi() {
-    return mmsi;
+  public String getDescription() {
+    return description;
   }
 
-  public void setMmsi(String mmsi) {
-    this.mmsi = mmsi;
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Integer getVesselMmsi() {
+    return vesselMmsi;
+  }
+
+  public void setVesselMmsi(Integer vesselMmsi) {
+    this.vesselMmsi = vesselMmsi;
+  }
+
+  public Integer getPortableMsi() {
+    return portableMsi;
+  }
+
+  public void setPortableMsi(Integer portableMsi) {
+    this.portableMsi = portableMsi;
   }
 
   public String getName() {
@@ -71,12 +93,12 @@ public class Vessel {
     this.radioComms = radioComms;
   }
 
-  public Integer getCapacity() {
-    return capacity;
+  public Integer getMaxCapacity() {
+    return maxCapacity;
   }
 
-  public void setCapacity(Integer capacity) {
-    this.capacity = capacity;
+  public void setMaxCapacity(Integer maxCapacity) {
+    this.maxCapacity = maxCapacity;
   }
 
   public String getVesselType() {
@@ -85,5 +107,53 @@ public class Vessel {
 
   public void setVesselType(String vesselType) {
     this.vesselType = vesselType;
+  }
+
+  public String getUksrId() {
+    return uksrId;
+  }
+
+  public void setUksrId(String uksrId) {
+    this.uksrId = uksrId;
+  }
+
+  public String getSafetraxId() {
+    return safetraxId;
+  }
+
+  public void setSafetraxId(String safetraxId) {
+    this.safetraxId = safetraxId;
+  }
+
+  public String getHomeport() {
+    return homeport;
+  }
+
+  public void setHomeport(String homeport) {
+    this.homeport = homeport;
+  }
+
+  public String getAreaOfUse() {
+    return areaOfUse;
+  }
+
+  public void setAreaOfUse(String areaOfUse) {
+    this.areaOfUse = areaOfUse;
+  }
+
+  public LocalDateTime getCreatedDate() {
+    return createdDate;
+  }
+
+  public void setCreatedDate(LocalDateTime createdDate) {
+    this.createdDate = createdDate;
+  }
+
+  public LocalDateTime getLastModifiedDate() {
+    return lastModifiedDate;
+  }
+
+  public void setLastModifiedDate(LocalDateTime lastModifiedDate) {
+    this.lastModifiedDate = lastModifiedDate;
   }
 }

--- a/src/main/resources/db/migration/V1.1__Add_Addition_Fields.sql
+++ b/src/main/resources/db/migration/V1.1__Add_Addition_Fields.sql
@@ -1,0 +1,21 @@
+ALTER TABLE beacons
+    ADD COLUMN chk_code text,
+    ADD COLUMN created_date TIMESTAMP,
+    ADD COLUMN last_modified_date TIMESTAMP;
+
+ALTER TABLE person
+    ADD COLUMN created_date TIMESTAMP,
+    ADD COLUMN last_modified_date TIMESTAMP;
+
+ALTER TABLE beacon_person
+    ADD COLUMN created_date TIMESTAMP,
+    ADD COLUMN last_modified_date TIMESTAMP;
+
+ALTER TABLE vessel
+    ADD COLUMN created_date TIMESTAMP,
+    ADD COLUMN last_modified_date TIMESTAMP;
+
+ALTER TABLE beacon_uses
+    ADD COLUMN location text,
+    ADD COLUMN created_date TIMESTAMP,
+    ADD COLUMN last_modified_date TIMESTAMP;

--- a/src/main/resources/db/migration/V1.1__Add_Addition_Fields.sql
+++ b/src/main/resources/db/migration/V1.1__Add_Addition_Fields.sql
@@ -1,11 +1,21 @@
 ALTER TABLE beacons
-    ADD COLUMN chk_code text,
+    ADD COLUMN checksum text,
     ADD COLUMN created_date TIMESTAMP,
-    ADD COLUMN last_modified_date TIMESTAMP;
+    ADD COLUMN last_modified_date TIMESTAMP,
+    ADD COLUMN beacon_status text NOT NULL,
+    ADD COLUMN coding text,
+    ADD COLUMN protocol_code text;
 
 ALTER TABLE person
     ADD COLUMN created_date TIMESTAMP,
-    ADD COLUMN last_modified_date TIMESTAMP;
+    ADD COLUMN last_modified_date TIMESTAMP,
+    ADD COLUMN postcode text,
+    ADD COLUMN country text,
+    ADD COLUMN care_of text,
+    DROP COLUMN address_line_5,
+    DROP COLUMN address_line_6,
+    DROP COLUMN address_line_7,
+    DROP COLUMN telephone;
 
 ALTER TABLE beacon_person
     ADD COLUMN created_date TIMESTAMP,
@@ -13,9 +23,28 @@ ALTER TABLE beacon_person
 
 ALTER TABLE vessel
     ADD COLUMN created_date TIMESTAMP,
-    ADD COLUMN last_modified_date TIMESTAMP;
+    ADD COLUMN last_modified_date TIMESTAMP,
+    ADD COLUMN description text,
+    DROP COLUMN mmsi,
+    ADD COLUMN portable_mmsi INTEGER,
+    ADD COLUMN vessel_mmsi INTEGER,
+    ADD COLUMN uksr_id text,
+    ADD COLUMN safetrax_id text,
+    ADD COLUMN homeport text,
+    ADD COLUMN area_of_use text;
+
+ALTER TABLE vessel
+    RENAME capacity TO max_capacity;
 
 ALTER TABLE beacon_uses
-    ADD COLUMN location text,
+    ADD COLUMN beacon_position text,
     ADD COLUMN created_date TIMESTAMP,
     ADD COLUMN last_modified_date TIMESTAMP;
+
+CREATE TABLE IF NOT EXISTS telephone
+(
+    id           uuid PRIMARY KEY,
+    person_id    uuid REFERENCES person (id) NOT NULL,
+    telephone    text,
+    relationship text
+);


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Adds `created_date` and `last_modified_date` columns to all tables
  - `Date Registered` for Beacons is a field that we saw in the MIRO wireframes
  - Might also be useful to have this info for back-office?

- Adds other columns seen on the wireframes
  - `chk_code` for beacons
  -  `location` for beacon_use


- Adds [Spring REST](https://docs.spring.io/spring-data/rest/docs/3.3.x/reference/html/#getting-started.setting-repository-detection-strategy) to the project, which exports all Repositories as endpoints
![image](https://user-images.githubusercontent.com/32230328/107213160-ebe28500-69ff-11eb-9fb6-faf519bc6836.png)
  - Have prevented `BeaconPerson` being exported as I don't think we need an endpoint for that
  - But let me know if you disagree, or if any other endpoint doesn't need to be exposed?
  - @matthew-a-carr and I also spoke about restricting access to the endpoints in the future (with e.g. [JWT](https://jwt.io/)?) - there is now an [issue for this](https://github.com/madetech/mca-beacons-service/issues/21).
 
- Allow `created_date` and `last_modified_date` to be populated when the Entity is created
  - Using [JPA's auditing functionality](https://www.baeldung.com/database-auditing-jpa#spring)
  - Saving these as `LocalDateTime` as the time might be relevant?

 
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
If you pull and run the service and the database, you can use this curl command to create a new Beacon:
```
curl -i -X POST -H "Content-Type:application/json" -d '{ "beaconType" : "Pleasure",
"hexId" : "2024F72524FFBFF",
"manufacturer" : "Made Tech",
"model" : "MCA",
"serialNumber" : "123456",
"batteryExpiry" : "2031-01-01",
"lastServiced" : "2021-01-01" }' http://localhost:8080/api/beacons
```

## Questions
### 1️⃣
Also, I saw `Temporary address` in the wireframes, does that mean adding another 7 columns in the person table? 😬 
![image](https://user-images.githubusercontent.com/32230328/107217984-e76d9a80-6a06-11eb-8b2c-84170142b45e.png)

### 2️⃣ 
It seems like Spring magic ✨ doesn't serialize the `created_date` and `last_modified_date` - are there other fields that we need to stop being serialized?
![image](https://user-images.githubusercontent.com/32230328/107219826-872c2800-6a09-11eb-955b-3c6e74062869.png)


### 3️⃣ 
In the wireframes, we have the field `Date registered` for a beacon, but for the name of the field, I've stuck to JPA's annotation `@CreatedDate` for the entity and table column 
- Would it be better to be consistent and rename the field `date registered`?
- But that might only work for the Beacon, and not be applicable to the other models?
![image](https://user-images.githubusercontent.com/32230328/107219992-b80c5d00-6a09-11eb-9d89-984e6cfa4f33.png)


## Link to Trello card
https://trello.com/c/mRSORbYY/181-form-flow-overall-user-journey-for-capturing-details-for-submitting-a-beacon

